### PR TITLE
Fix: multiple concourse clusters cannot be bootup in the same aws account.

### DIFF
--- a/autoscaling/hooks/enabled/main.tf
+++ b/autoscaling/hooks/enabled/main.tf
@@ -2,11 +2,11 @@
 # https://dzone.com/articles/graceful-shutdown-using-aws-autoscaling-groups-and
 
 resource "aws_sqs_queue" "graceful_termination_queue" {
-  name = "graceful_termination_queue"
+  name = "${var.prefix}graceful_termination_queue"
 }
 
 resource "aws_iam_role" "autoscaling_role" {
-  name = "autoscaling_role"
+name = "${var.prefix}autoscaling_role"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -64,4 +64,8 @@ output "sqs_queue_arn" {
 }
 
 variable "target_asg_name" {
+}
+
+variable "prefix" {
+
 }

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,7 @@ provider "aws" {
 module "autoscaling_hooks" {
     source = "./autoscaling/hooks/enabled"
     target_asg_name = "${aws_autoscaling_group.worker-asg.name}"
+    prefix = "${var.prefix}"
 }
 
 module "autoscaling_schedule" {
@@ -147,7 +148,7 @@ resource "aws_launch_configuration" "worker-lc" {
     create_before_destroy = true
   }
 }
-  
+
 resource "template_file" "install_concourse" {
   template = "${file("${path.module}/00_install_concourse.sh.tpl")}"
 }


### PR DESCRIPTION
Added necessary prefixes to resources in autoscaling/hooks/enabled so that multiple concourse clusters can be provisioned in the same aws account.

We need to put prefix to names of iam_role and sqs becase they exist independently to target auto scaling group.
