### PR TITLE
update xenial base ami and add apt-get update in building ami

### DIFF
--- a/build-docker-ami.sh
+++ b/build-docker-ami.sh
@@ -2,4 +2,4 @@
 
 set -eu
 
-packer build -var source_ami=ami-5d38d93c docker-baked.json
+packer build -var source_ami=ami-b7d829d6 docker-baked.json

--- a/docker-baked.json
+++ b/docker-baked.json
@@ -17,6 +17,7 @@
     "type": "shell",
     "inline": [
       "uname -a",
+      "sudo apt-get update",
       "sudo apt-get install apt-transport-https ca-certificates -y",
       "sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D",
       "sudo bash -c 'echo deb https://apt.dockerproject.org/repo ubuntu-xenial main > /etc/apt/sources.list.d/docker.list'",


### PR DESCRIPTION
`./build-amis.sh` was carshed when I tried it today.  The reason would be source_ami is a bit old. 
- update source_ami for the latest xenial one
- add 'apt-get update' to docker-baked.json.  this is required when specified source_ami is old enough.

This is an error I faced.

```
 $ ./build-amis.sh
amazon-ebs output will be in this color.

==> amazon-ebs: Prevalidating AMI Name...
==> amazon-ebs: Inspecting the source AMI...
==> amazon-ebs: Creating temporary keypair: packer 5785d98c-e949-6cbb-57ef-411b57f18cfd
==> amazon-ebs: Creating temporary security group for this instance...
==> amazon-ebs: Authorizing access to port 22 the temporary security group...
==> amazon-ebs: Launching a source AWS instance...
    amazon-ebs: Instance ID: i-08f51fae36fbfeeae
==> amazon-ebs: Waiting for instance (i-08f51fae36fbfeeae) to become ready...
==> amazon-ebs: Waiting for SSH to become available...
==> amazon-ebs: Connected to SSH!
==> amazon-ebs: Provisioning with shell script: /var/folders/n3/ltr_z1f90f31r9kyy6d_ljk80000gn/T/packer-shell164124215
    amazon-ebs: Linux ip-172-31-4-172 4.4.0-22-generic #40-Ubuntu SMP Thu May 12 22:03:46 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux
    amazon-ebs: Reading package lists...
    amazon-ebs: Building dependency tree...
    amazon-ebs: Reading state information...
    amazon-ebs: apt-transport-https is already the newest version (1.2.10ubuntu1).
    amazon-ebs: ca-certificates is already the newest version (20160104ubuntu1).
  1 we need 'apt-get update' when package info cache is old in source_ami.↲
    amazon-ebs: 0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
    amazon-ebs: Executing: /tmp/tmp.eYWUVonvIw/gpg.1.sh --keyserver
    amazon-ebs: hkp://p80.pool.sks-keyservers.net:80
    amazon-ebs: --recv-keys
    amazon-ebs: 58118E89F3A912897C070ADBF76221572C52609D
    amazon-ebs: gpg: requesting key 2C52609D from hkp server p80.pool.sks-keyservers.net
    amazon-ebs: gpg: key 2C52609D: public key "Docker Release Tool (releasedocker) <docker@docker.com>" imported
    amazon-ebs: gpg: Total number processed: 1
    amazon-ebs: gpg:               imported: 1  (RSA: 1)
    amazon-ebs: Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [94.5 kB]
    amazon-ebs: Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease
    amazon-ebs: Get:3 https://apt.dockerproject.org/repo ubuntu-xenial InRelease [20.6 kB]
    amazon-ebs: Get:4 https://apt.dockerproject.org/repo ubuntu-xenial/main amd64 Packages [1,719 B]
    amazon-ebs: Get:5 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [95.7 kB]
    amazon-ebs: Get:6 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [119 kB]
    amazon-ebs: Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [254 kB]
    amazon-ebs: Get:10 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [101 kB]
    amazon-ebs: Get:11 http://security.ubuntu.com/ubuntu xenial-security/universe Translation-en [21.2 kB]
    amazon-ebs: Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [165 kB]
    amazon-ebs: Get:13 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [1,176 B]
    amazon-ebs: Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [79.6 kB]
    amazon-ebs: Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [3,332 B]
    amazon-ebs: Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse Translation-en [1,540 B]
    amazon-ebs: Fetched 1,039 kB in 3s (294 kB/s)
    amazon-ebs: Reading package lists...
    amazon-ebs: docker-engine:
    amazon-ebs: Installed: (none)
    amazon-ebs: Candidate: 1.11.2-0~xenial
    amazon-ebs: --recv-keys                                                                                                                                                                                                                            [27/619]
    amazon-ebs: 58118E89F3A912897C070ADBF76221572C52609D
    amazon-ebs: gpg: requesting key 2C52609D from hkp server p80.pool.sks-keyservers.net
    amazon-ebs: gpg: key 2C52609D: public key "Docker Release Tool (releasedocker) <docker@docker.com>" imported
    amazon-ebs: gpg: Total number processed: 1
    amazon-ebs: gpg:               imported: 1  (RSA: 1)
    amazon-ebs: Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [94.5 kB]
    amazon-ebs: Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease
    amazon-ebs: Get:3 https://apt.dockerproject.org/repo ubuntu-xenial InRelease [20.6 kB]
    amazon-ebs: Get:4 https://apt.dockerproject.org/repo ubuntu-xenial/main amd64 Packages [1,719 B]
    amazon-ebs: Get:5 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [95.7 kB]
    amazon-ebs: Get:6 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [119 kB]
    amazon-ebs: Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [254 kB]
    amazon-ebs: Get:8 http://security.ubuntu.com/ubuntu xenial-security/main Translation-en [45.3 kB]
    amazon-ebs: Get:9 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [35.4 kB]
    amazon-ebs: Get:10 http://archive.ubuntu.com/ubuntu xenial-updates/main Translation-en [101 kB]
    amazon-ebs: Get:11 http://security.ubuntu.com/ubuntu xenial-security/universe Translation-en [21.2 kB]
    amazon-ebs: Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [165 kB]
    amazon-ebs: Get:13 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [1,176 B]
    amazon-ebs: Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/universe Translation-en [79.6 kB]
    amazon-ebs: Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [3,332 B]
    amazon-ebs: Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse Translation-en [1,540 B]
    amazon-ebs: Fetched 1,039 kB in 3s (294 kB/s)
    amazon-ebs: Reading package lists...
    amazon-ebs: docker-engine:
    amazon-ebs: Installed: (none)
    amazon-ebs: Candidate: 1.11.2-0~xenial
    amazon-ebs: Version table:
    amazon-ebs: 1.11.2-0~xenial 500
    amazon-ebs: 500 https://apt.dockerproject.org/repo ubuntu-xenial/main amd64 Packages
    amazon-ebs: 1.11.1-0~xenial 500
    amazon-ebs: 500 https://apt.dockerproject.org/repo ubuntu-xenial/main amd64 Packages
    amazon-ebs: 1.11.0-0~xenial 500
    amazon-ebs: 500 https://apt.dockerproject.org/repo ubuntu-xenial/main amd64 Packages
    amazon-ebs: Reading package lists...
    amazon-ebs: Building dependency tree...
    amazon-ebs: Reading state information...
    amazon-ebs: Some packages could not be installed. This may mean that you have
    amazon-ebs: requested an impossible situation or if you are using the unstable
    amazon-ebs: distribution that some required packages have not yet been created
    amazon-ebs: or been moved out of Incoming.
    amazon-ebs: The following information may help to resolve the situation:
    amazon-ebs:
    amazon-ebs: The following packages have unmet dependencies:
    amazon-ebs: docker-engine : Depends: libltdl7 (>= 2.4.6) but it is not installable
    amazon-ebs: Recommends: aufs-tools but it is not installable
    amazon-ebs: E: Unable to correct problems, you have held broken packages.
    amazon-ebs: Recommends: cgroupfs-mount but it is not installable or
    amazon-ebs: cgroup-lite but it is not installable
==> amazon-ebs: Terminating the source AWS instance...
==> amazon-ebs: No AMIs to cleanup
==> amazon-ebs: Deleting temporary security group...
==> amazon-ebs: Deleting temporary keypair...
Build 'amazon-ebs' errored: Script exited with non-zero exit status: 100

==> Some builds didn't complete successfully and had errors:
--> amazon-ebs: Script exited with non-zero exit status: 100

==> Builds finished but no artifacts were created.

```
