### PR TITLE
make more variables be configurable in cluster.yml

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -112,6 +112,11 @@ func InteractivelyCreateConfig() *concourse.Config {
 	dbInstanceClass := AskForRequiredInput("DB Instance Class", AskOptions{Default: "db.t2.micro"})
 	instanceType := AskForRequiredInput("Concourse Instance Type", AskOptions{Default: "t2.micro"})
 
+	asgMin := AskForRequiredInput("Min numbers of servers in ASG(Web, Worker)", AskOptions{Default: "0"})
+	asgMax := AskForRequiredInput("Max numbers of servers in ASG(Web, Worker)", AskOptions{Default: "2"})
+	webAsgDesired := AskForRequiredInput("Desired numbers of web servers in ASG", AskOptions{Default: "1"})
+	workerAsgDesired := AskForRequiredInput("Desired numbers of servers in ASG", AskOptions{Default: "2"})
+
 	possibleElbProtocols := []string{"http", "https"}
 	defaultElbPorts := map[string]string{
 		"http":  "80",
@@ -186,6 +191,10 @@ func InteractivelyCreateConfig() *concourse.Config {
 		DBInstanceClass:          dbInstanceClass,
 		InstanceType:             instanceType,
 		AMI:                      amiId,
+		AsgMin:                   asgMin,
+		AsgMax:                   asgMax,
+		WebAsgDesired:            webAsgDesired,
+		WorkerAsgDesired:         workerAsgDesired,
 		ElbProtocol:              elbProtocol,
 		ElbPort:                  elbPort,
 		CustomExternalDomainName: customExternalDomainName,
@@ -282,11 +291,34 @@ func TerraformRun(subcommand string, c *concourse.Config) {
 		"-var", fmt.Sprintf("github_auth_client_id=%s", c.GithubAuthClientId),
 		"-var", fmt.Sprintf("github_auth_client_secret=%s", c.GithubAuthClientSecret),
 	}
+
 	if len(c.Prefix) > 0 {
 		args = append(args,
 			"-var", fmt.Sprintf("prefix=%s", c.Prefix),
 		)
 	}
+
+	if len(c.AsgMin) > 0 {
+		args = append(args,
+			"-var", fmt.Sprintf("asg_min=%s", c.AsgMin),
+		)
+	}
+	if len(c.AsgMax) > 0 {
+		args = append(args,
+			"-var", fmt.Sprintf("asg_max=%s", c.AsgMax),
+		)
+	}
+	if len(c.WebAsgDesired) > 0 {
+		args = append(args,
+			"-var", fmt.Sprintf("web_asg_desired=%s", c.WebAsgDesired),
+		)
+	}
+	if len(c.WorkerAsgDesired) > 0 {
+		args = append(args,
+			"-var", fmt.Sprintf("worker_asg_desired=%s", c.WorkerAsgDesired),
+		)
+	}
+
 	if len(c.GithubAuthOrganizations) > 0 {
 		args = append(args,
 			"-var", fmt.Sprintf("github_auth_organizations=%s", strings.Join(c.GithubAuthOrganizations, ",")),

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -69,6 +69,8 @@ func mustBeIncludedIn(candidates []string) func(string) error {
 }
 
 func InteractivelyCreateConfig() *concourse.Config {
+	prefix := AskForRequiredInput("Prefix", AskOptions{Default: "concourse-"})
+
 	regions := ListRegions()
 	region := AskForRequiredInput("Region", AskOptions{Candidates: regions, Validate: mustBeIncludedIn(regions), Default: "ap-northeast-1"})
 
@@ -174,6 +176,7 @@ func InteractivelyCreateConfig() *concourse.Config {
 	}
 
 	return &concourse.Config{
+		Prefix:                   prefix,
 		Region:                   region,
 		KeyName:                  keyName,
 		AccessibleCIDRS:          accessibleCIDRS,
@@ -278,6 +281,11 @@ func TerraformRun(subcommand string, c *concourse.Config) {
 		"-var", fmt.Sprintf("basic_auth_password=%s", c.BasicAuthPassword),
 		"-var", fmt.Sprintf("github_auth_client_id=%s", c.GithubAuthClientId),
 		"-var", fmt.Sprintf("github_auth_client_secret=%s", c.GithubAuthClientSecret),
+	}
+	if len(c.Prefix) > 0 {
+		args = append(args,
+			"-var", fmt.Sprintf("prefix=%s", c.Prefix),
+		)
 	}
 	if len(c.GithubAuthOrganizations) > 0 {
 		args = append(args,

--- a/concourse/config.go
+++ b/concourse/config.go
@@ -19,6 +19,10 @@ type Config struct {
 	InstanceType             string   `yaml:"instance_type"`
 	WorkerInstanceProfile    string   `yaml:"worker_instance_profile"`
 	AMI                      string   `yaml:"ami_id"`
+	AsgMin                   string   `yaml:"asg_min"`
+	AsgMax                   string   `yaml:"asg_max"`
+	WebAsgDesired            string   `yaml:"web_asg_desired"`
+	WorkerAsgDesired         string   `yaml:"worker_asg_desired"`
 	ElbProtocol              string   `yaml:"elb_protocol"`
 	ElbPort                  int      `yaml:"elb_port"`
 	CustomExternalDomainName string   `yaml:"custom_external_domain_name"`

--- a/concourse/config.go
+++ b/concourse/config.go
@@ -8,7 +8,8 @@ import (
 )
 
 type Config struct {
-	Region                   string
+	Prefix                   string   `yaml:"prefix"`
+	Region                   string   `yaml:"region"`
 	KeyName                  string   `yaml:"key_name"`
 	SubnetIds                []string `yaml:"subnet_ids"`
 	VpcId                    string   `yaml:"vpc_id"`

--- a/concourse/config_test.go
+++ b/concourse/config_test.go
@@ -19,6 +19,10 @@ subnet_ids:
   - subnet-11111914
   - subnet-2222fc48
 accessible_cidrs: 123.123.234.234/32,234.234.234.234/32
+asg_min: 0
+asg_max: 2
+web_asg_desired: 1
+worker_asg_desired: 2
 github_auth_client_id: dummydummy
 github_auth_client_secret: dummydummydummy
 github_auth_organizations: [org1, org2]
@@ -35,6 +39,10 @@ ssl_certificate_arn: "arn://dummydummy"
 			KeyName:                  "cw_kuoka",
 			SubnetIds:                []string{"subnet-11111914", "subnet-2222fc48"},
 			AccessibleCIDRS:          "123.123.234.234/32,234.234.234.234/32",
+			AsgMin:                   "0",
+			AsgMax:                   "2",
+			WebAsgDesired:            "1",
+			WorkerAsgDesired:         "2",
 			ElbProtocol:              "https",
 			ElbPort:                  443,
 			CustomExternalDomainName: "some.where",

--- a/concourse/config_test.go
+++ b/concourse/config_test.go
@@ -12,6 +12,7 @@ var validConfigs = []struct {
 	{
 		providedYaml: `
 ---
+prefix: sample
 region: ap-northeast-1
 key_name: cw_kuoka
 subnet_ids:
@@ -29,6 +30,7 @@ custom_external_domain_name: "some.where"
 ssl_certificate_arn: "arn://dummydummy"
 `,
 		expectedConfig: Config{
+			Prefix:                   "sample",
 			Region:                   "ap-northeast-1",
 			KeyName:                  "cw_kuoka",
 			SubnetIds:                []string{"subnet-11111914", "subnet-2222fc48"},


### PR DESCRIPTION
I made these two variables be configurable from `cluster.yml`
- `Prefix`
- ASG related variables `asg_{min|max}`,`{web|worker}_asg_desired`

I will open new PR to support syncing assets(cluster.yml, ssh keys, tfstate) with S3. 
