### PR TITLE
bump concourse to 2.5.1

### DIFF
--- a/02_start_concourse_worker.sh.tpl
+++ b/02_start_concourse_worker.sh.tpl
@@ -22,6 +22,8 @@ service docker stop
 concourse worker \
   --work-dir $CONCOURSE_PATH \
   --peer-ip $(cat peer_ip) \
+  --bind-ip $(cat peer_ip) \
+  --baggageclaim-bind-ip $(cat peer_ip) \
   --tsa-host $(cat tsa_host) \
   --tsa-public-key tsa_public_key \
   --tsa-worker-private-key tsa_worker_private_key 2>&1 > $CONCOURSE_PATH/concourse_worker.log &

--- a/concourse-baked.json
+++ b/concourse-baked.json
@@ -11,13 +11,13 @@
     "source_ami": "{{user `source_ami`}}",
     "instance_type": "t2.micro",
     "ssh_username": "ubuntu",
-    "ami_name": "packer-concourse-v2.2.1-{{timestamp}}"
+    "ami_name": "packer-concourse-v2.5.1-{{timestamp}}"
   }],
   "provisioners": [{
     "type": "shell",
     "inline": [
       "uname -a",
-      "curl -v -L https://github.com/concourse/concourse/releases/download/v2.2.1/concourse_linux_amd64 -o concourse",
+      "curl -v -L https://github.com/concourse/concourse/releases/download/v2.5.1/concourse_linux_amd64 -o concourse",
       "chmod +x concourse",
       "sudo mv concourse /usr/local/bin/concourse"
     ]


### PR DESCRIPTION
* fixes #15. 
* `bind-ip` and `baggageclaim-bind-ip` was needed for worker registering to atc properly.