### PR TITLE
make db_engine_version configurable.

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -105,6 +105,7 @@ func InteractivelyCreateConfig() *concourse.Config {
 	accessibleCIDRS := AskForRequiredInput("AccessibleCIDRS(commma separated)", AskOptions{Default: fmt.Sprintf("%s/32", ObtainExternalIp())})
 
 	dbInstanceClass := AskForRequiredInput("DB Instance Class", AskOptions{Default: "db.t2.micro"})
+	dbEngineVersion := AskForRequiredInput("DB Engine(Postgres) Version", AskOptions{Default: "9.4.7"})
 	instanceType := AskForRequiredInput("Concourse Instance Type", AskOptions{Default: "t2.micro"})
 
 	asgMin := AskForRequiredInput("Min numbers of servers in ASG(Web, Worker)", AskOptions{Default: "0"})
@@ -184,6 +185,7 @@ func InteractivelyCreateConfig() *concourse.Config {
 		SubnetIds:                subnetIds,
 		AvailabilityZones:        availabilityZones,
 		DBInstanceClass:          dbInstanceClass,
+		DBEngineVersion:          dbEngineVersion,
 		InstanceType:             instanceType,
 		AMI:                      amiId,
 		AsgMin:                   asgMin,
@@ -268,6 +270,7 @@ func TerraformRun(subcommand string, c *concourse.Config) {
 		"-var", fmt.Sprintf("subnet_id=%s", strings.Join(c.SubnetIds, ",")),
 		"-var", fmt.Sprintf("vpc_id=%s", c.VpcId),
 		"-var", fmt.Sprintf("db_instance_class=%s", c.DBInstanceClass),
+		"-var", fmt.Sprintf("db_engine_version=%s", c.DBEngineVersion),
 		"-var", fmt.Sprintf("instance_type=%s", c.InstanceType),
 		"-var", "db_username=concourse",
 		"-var", "db_password=concourse",

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -107,7 +107,7 @@ func InteractivelyCreateConfig() *concourse.Config {
 	dbInstanceClass := AskForRequiredInput("DB Instance Class", AskOptions{Default: "db.t2.micro"})
 	dbEngineVersion := AskForRequiredInput("DB Engine(Postgres) Version", AskOptions{Default: "9.4.7"})
 
-  webInstanceType := AskForRequiredInput("Concourse Web Instance Type", AskOptions{Default: "t2.micro"})
+	webInstanceType := AskForRequiredInput("Concourse Web Instance Type", AskOptions{Default: "t2.micro"})
 	workerInstanceType := AskForRequiredInput("Concourse Worker Instance Type", AskOptions{Default: "t2.micro"})
 
 	asgMin := AskForRequiredInput("Min numbers of servers in ASG(Web, Worker)", AskOptions{Default: "0"})

--- a/concourse/config.go
+++ b/concourse/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	AvailabilityZones        []string `yaml:"availability_zones"`
 	AccessibleCIDRS          string   `yaml:"accessible_cidrs"`
 	DBInstanceClass          string   `yaml:"db_instance_class"`
+	DBEngineVersion          string   `yaml:"db_engine_version"`
 	InstanceType             string   `yaml:"instance_type"`
 	WorkerInstanceProfile    string   `yaml:"worker_instance_profile"`
 	AMI                      string   `yaml:"ami_id"`

--- a/concourse/config_test.go
+++ b/concourse/config_test.go
@@ -19,6 +19,7 @@ subnet_ids:
   - subnet-11111914
   - subnet-2222fc48
 accessible_cidrs: 123.123.234.234/32,234.234.234.234/32
+db_engine_version: "9.4.7"
 asg_min: 0
 asg_max: 2
 web_asg_desired: 1
@@ -39,6 +40,7 @@ ssl_certificate_arn: "arn://dummydummy"
 			KeyName:                  "cw_kuoka",
 			SubnetIds:                []string{"subnet-11111914", "subnet-2222fc48"},
 			AccessibleCIDRS:          "123.123.234.234/32,234.234.234.234/32",
+			DBEngineVersion:          "9.4.7",
 			AsgMin:                   "0",
 			AsgMax:                   "2",
 			WebAsgDesired:            "1",

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "prefix" {
   description = "Prefix for every resource created by this template"
-  default = "concourse-"  
+  default = "concourse-"
 }
 
 variable "aws_region" {
@@ -99,6 +99,10 @@ variable "db_password" {
 
 variable "db_instance_class" {
   description = "t2.micro"
+}
+
+variable "db_engine_version" {
+  description = "engine version of rds engine ('postgres')"
 }
 
 variable "tsa_host_key" {


### PR DESCRIPTION
In default setting, rds instance (postgres) will be upgraded minor version automatically because `auto_minor_upgrade` 's default value is [true](https://www.terraform.io/docs/providers/aws/r/db_instance.html#auto_minor_version_upgrade)

However, `cluster.yml` doesn't have the parameter, so user will face error in `terraform plan` phase.

This PR fixes the issue.