### PR TITLE
make web/worker instance type configurable independently.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 host_key*
 session_signing_key*
 worker_key*

--- a/concourse/config.go
+++ b/concourse/config.go
@@ -8,15 +8,18 @@ import (
 )
 
 type Config struct {
-	Prefix                   string   `yaml:"prefix"`
-	Region                   string   `yaml:"region"`
-	KeyName                  string   `yaml:"key_name"`
-	SubnetIds                []string `yaml:"subnet_ids"`
-	VpcId                    string   `yaml:"vpc_id"`
-	AvailabilityZones        []string `yaml:"availability_zones"`
-	AccessibleCIDRS          string   `yaml:"accessible_cidrs"`
-	DBInstanceClass          string   `yaml:"db_instance_class"`
+	Prefix            string   `yaml:"prefix"`
+	Region            string   `yaml:"region"`
+	KeyName           string   `yaml:"key_name"`
+	SubnetIds         []string `yaml:"subnet_ids"`
+	VpcId             string   `yaml:"vpc_id"`
+	AvailabilityZones []string `yaml:"availability_zones"`
+	AccessibleCIDRS   string   `yaml:"accessible_cidrs"`
+	DBInstanceClass   string   `yaml:"db_instance_class"`
+	// Deprecated: Use WebInstanceType and WorkerInstanceType instead.
 	InstanceType             string   `yaml:"instance_type"`
+	WebInstanceType          string   `yaml:"web_instance_type"`
+	WorkerInstanceType       string   `yaml:"worker_instance_type"`
 	WorkerInstanceProfile    string   `yaml:"worker_instance_profile"`
 	AMI                      string   `yaml:"ami_id"`
 	AsgMin                   string   `yaml:"asg_min"`

--- a/concourse/config_test.go
+++ b/concourse/config_test.go
@@ -15,6 +15,8 @@ var validConfigs = []struct {
 prefix: sample
 region: ap-northeast-1
 key_name: cw_kuoka
+web_instance_type: t2.small
+worker_instance_type: t2.medium
 subnet_ids:
   - subnet-11111914
   - subnet-2222fc48
@@ -37,6 +39,9 @@ ssl_certificate_arn: "arn://dummydummy"
 			Prefix:                   "sample",
 			Region:                   "ap-northeast-1",
 			KeyName:                  "cw_kuoka",
+			InstanceType:             "",
+			WebInstanceType:          "t2.small",
+			WorkerInstanceType:       "t2.medium",
 			SubnetIds:                []string{"subnet-11111914", "subnet-2222fc48"},
 			AccessibleCIDRS:          "123.123.234.234/32,234.234.234.234/32",
 			AsgMin:                   "0",

--- a/main.tf
+++ b/main.tf
@@ -106,7 +106,7 @@ resource "aws_launch_configuration" "web-lc" {
   # ref. https://github.com/hashicorp/terraform/issues/1109#issuecomment-97970885
   #image_id = "${lookup(var.aws_amis, var.aws_region)}"
   image_id = "${var.ami}"
-  instance_type = "${var.instance_type}"
+  instance_type = "${var.web_instance_type}"
   security_groups = ["${aws_security_group.default.id}","${aws_security_group.atc.id}","${aws_security_group.tsa.id}"]
   user_data = "${template_cloudinit_config.web.rendered}"
   key_name = "${var.key_name}"
@@ -119,7 +119,7 @@ resource "aws_launch_configuration" "web-lc" {
 resource "aws_launch_configuration" "worker-lc" {
   #image_id = "${lookup(var.aws_amis, var.aws_region)}"
   image_id = "${var.ami}"
-  instance_type = "${var.instance_type}"
+  instance_type = "${var.worker_instance_type}"
   security_groups = ["${aws_security_group.default.id}", "${aws_security_group.worker.id}"]
   user_data = "${template_cloudinit_config.worker.rendered}"
   key_name = "${var.key_name}"

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "prefix" {
   description = "Prefix for every resource created by this template"
-  default = "concourse-"  
+  default = "concourse-"
 }
 
 variable "aws_region" {
@@ -29,9 +29,14 @@ variable "key_name" {
   description = "Name of AWS key pair"
 }
 
-variable "instance_type" {
+variable "web_instance_type" {
   default = "t2.micro"
-  description = "AWS instance type"
+  description = "AWS instance type for web"
+}
+
+variable "worker_instance_type" {
+  default = "t2.micro"
+  description = "AWS instance type for worker"
 }
 
 variable "asg_min" {


### PR DESCRIPTION
In most cases, hardware requirements for web servers and workers are different.  So, instance types of those should be configurable independetly.

This PR contains changes below:
- deprecate `instance_type`
- introduce `web_instance_type` and `worker_instance_type`
- introduce  backward compatibility code in `cmd/up.go`