### PR TITLE
iam roles cannot be used when packer runs

### DIFF
--- a/concourse-baked.json
+++ b/concourse-baked.json
@@ -1,12 +1,6 @@
 {
-  "variables": {
-    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
-    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}"
-  },
   "builders": [{
     "type": "amazon-ebs",
-    "access_key": "{{user `aws_access_key`}}",
-    "secret_key": "{{user `aws_secret_key`}}",
     "region": "ap-northeast-1",
     "source_ami": "{{user `source_ami`}}",
     "instance_type": "t2.micro",

--- a/docker-baked.json
+++ b/docker-baked.json
@@ -1,12 +1,6 @@
 {
-  "variables": {
-    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
-    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}"
-  },
   "builders": [{
     "type": "amazon-ebs",
-    "access_key": "{{user `aws_access_key`}}",
-    "secret_key": "{{user `aws_secret_key`}}",
     "region": "ap-northeast-1",
     "source_ami": "{{user `source_ami`}}",
     "instance_type": "t2.micro",

--- a/packer.json
+++ b/packer.json
@@ -1,12 +1,6 @@
 {
-  "variables": {
-    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
-    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}"
-  },
   "builders": [{
     "type": "amazon-ebs",
-    "access_key": "{{user `aws_access_key`}}",
-    "secret_key": "{{user `aws_secret_key`}}",
     "region": "ap-northeast-1",
     "source_ami": "ami-5d38d93c",
     "instance_type": "t2.micro",


### PR DESCRIPTION
Nowadays people tend to not use AWS IAM users anymore, but
roles through Identity Federation.
Assuming a role (STS) set a aws session token which packer
configuration doesn't support, but the aws lib used by
packer supports it through environment variables.