### PR TITLE
fix CVE-2017-1000117

### DIFF
--- a/build-docker-ami.sh
+++ b/build-docker-ami.sh
@@ -2,4 +2,4 @@
 
 set -eu
 
-packer build -var source_ami=ami-b7d829d6 docker-baked.json
+packer build -var source_ami=ami-0417e362 docker-baked.json

--- a/docker-baked.json
+++ b/docker-baked.json
@@ -12,6 +12,7 @@
     "inline": [
       "uname -a",
       "sudo apt-get update",
+      "sudo apt-get --yes upgrade",
       "sudo apt-get install apt-transport-https ca-certificates -y",
       "sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D",
       "sudo bash -c 'echo deb https://apt.dockerproject.org/repo ubuntu-xenial main > /etc/apt/sources.list.d/docker.list'",

--- a/packer.json
+++ b/packer.json
@@ -2,7 +2,7 @@
   "builders": [{
     "type": "amazon-ebs",
     "region": "ap-northeast-1",
-    "source_ami": "ami-5d38d93c",
+    "source_ami": "ami-0417e362",
     "instance_type": "t2.micro",
     "ssh_username": "ubuntu",
     "ami_name": "packer-ubuntu-xenial-{{timestamp}}"


### PR DESCRIPTION
This PR contains followings:

- add 'apt-get upgrade' to docker-baked.json, cause to fix CVE-2017-1000117.
- update source_ami to the latest xenial one at this time.
