### PR TITLE
remove docker-engine package

### DIFF
--- a/docker-baked.json
+++ b/docker-baked.json
@@ -12,16 +12,7 @@
     "inline": [
       "uname -a",
       "sudo apt-get update",
-      "sudo apt-get --yes upgrade",
-      "sudo apt-get install apt-transport-https ca-certificates -y",
-      "sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D",
-      "sudo bash -c 'echo deb https://apt.dockerproject.org/repo ubuntu-xenial main > /etc/apt/sources.list.d/docker.list'",
-      "sudo apt-get update",
-      "sudo apt-cache policy docker-engine",
-      "sudo apt-get install docker-engine -y",
-      "#sudo service docker start",
-      "sudo docker info",
-      "sudo docker run hello-world"
+      "sudo apt-get --yes upgrade"
     ]
   }]
 }


### PR DESCRIPTION
When I execute "concourse-aws up" after create a new AMI by "build-ami.sh", the worker node encountered problems communicating with the outside.

It was solved by deleting docker-engine package.

Probably docker-engine package is not necessary.